### PR TITLE
Develop

### DIFF
--- a/src/PubSubQueue.php
+++ b/src/PubSubQueue.php
@@ -133,7 +133,6 @@ class PubSubQueue extends Queue implements QueueContract
             );
         } else {
             $subscription->delete();
-            $topic->delete();
         }
     }
 

--- a/tests/Unit/Connectors/PubSubConnectorTests.php
+++ b/tests/Unit/Connectors/PubSubConnectorTests.php
@@ -12,6 +12,7 @@ class PubSubConnectorTests extends TestCase
 {
     public function testImplementsConnectorInterface()
     {
+        putenv('SUPPRESS_GCLOUD_CREDS_WARNING=true');
         $reflection = new ReflectionClass(PubSubConnector::class);
         $this->assertTrue($reflection->implementsInterface(ConnectorInterface::class));
     }

--- a/tests/Unit/PubSubQueueTests.php
+++ b/tests/Unit/PubSubQueueTests.php
@@ -135,9 +135,6 @@ class PubSubQueueTests extends TestCase
         $this->topic->method('exists')
             ->willReturn(true);
 
-        $this->topic->expects($this->once())
-            ->method('delete');
-
         $this->queue->method('getTopic')
             ->willReturn($this->topic);
 


### PR DESCRIPTION
A topic must not be deleted once it has been created. And error will be raised by google when trying to create a topic that has the same name as one deleted recently.

The best thing to do is to delete it manually if it's needed.

