### PR TITLE
Fix version number

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php" : ">=7.1",
-        "illuminate/queue": "^5.6",
+        "illuminate/queue": "^5.6 < 5.7.7",
         "google/cloud-pubsub": "^1.1"
     },
     "require-dev": {


### PR DESCRIPTION
There was a breaking change in illuminate/queue 5.7.7 which is incompatible
with laravel-pubsub-queue.

See https://github.com/laravel/framework/blob/3c278f372eaf139cefc98aacd716604f71866264/src/Illuminate/Queue/Queue.php#L86 for reference.

This is the cause of the most recent failing build.