### PR TITLE
Acknowledge message immediately

### DIFF
--- a/src/Jobs/PubSubJob.php
+++ b/src/Jobs/PubSubJob.php
@@ -63,18 +63,6 @@ class PubSubJob extends Job implements JobContract
     }
 
     /**
-     * Delete the job from the queue.
-     *
-     * @return void
-     */
-    public function delete()
-    {
-        parent::delete();
-
-        $this->pubsub->acknowledge($this->job, $this->queue);
-    }
-
-    /**
      * Get the number of times the job has been attempted.
      *
      * @return int
@@ -95,7 +83,7 @@ class PubSubJob extends Job implements JobContract
         parent::release($delay);
 
         $attempts = $this->attempts() + 1;
-        $this->pubsub->acknowledgeAndPublish(
+        $this->pubsub->republish(
             $this->job,
             $this->queue,
             ['attempts' => $attempts],

--- a/src/PubSubQueue.php
+++ b/src/PubSubQueue.php
@@ -129,6 +129,8 @@ class PubSubQueue extends Queue implements QueueContract
         ]);
 
         if (! empty($messages) && count($messages) > 0) {
+            $this->acknowledge($messages[0], $queue);
+
             return new PubSubJob(
                 $this->container,
                 $this,
@@ -176,19 +178,16 @@ class PubSubQueue extends Queue implements QueueContract
     }
 
     /**
-     * Acknowledge a message and republish it onto the queue.
+     * Republish a message onto the queue.
      *
      * @param  \Google\Cloud\PubSub\Message $message
      * @param  string $queue
      *
      * @return mixed
      */
-    public function acknowledgeAndPublish(Message $message, $queue = null, $options = [], $delay = 0)
+    public function republish(Message $message, $queue = null, $options = [], $delay = 0)
     {
         $topic = $this->getTopic($queue);
-        $subscription = $topic->subscription($this->getSubscriberName());
-
-        $subscription->acknowledge($message);
 
         $options = array_merge([
             'available_at' => $this->availableAt($delay),

--- a/tests/Unit/Jobs/PubSubJobTests.php
+++ b/tests/Unit/Jobs/PubSubJobTests.php
@@ -65,14 +65,6 @@ class PubSubJobTests extends TestCase
         $this->assertEquals($this->job->getRawBody(), $this->messageData);
     }
 
-    public function testDeleteAcknowledge()
-    {
-        $this->queue->expects($this->once())
-            ->method('acknowledge');
-
-        $this->job->delete();
-    }
-
     public function testDeleteMethodSetDeletedProperty()
     {
         $this->job->delete();
@@ -84,10 +76,10 @@ class PubSubJobTests extends TestCase
         $this->assertTrue(is_int($this->job->attempts()));
     }
 
-    public function testReleaseAcknowledgeAndPublish()
+    public function testReleaseAndPublish()
     {
         $this->queue->expects($this->once())
-            ->method('acknowledgeAndPublish');
+            ->method('republish');
 
         $this->job->release();
     }

--- a/tests/Unit/PubSubQueueTests.php
+++ b/tests/Unit/PubSubQueueTests.php
@@ -113,6 +113,9 @@ class PubSubQueueTests extends TestCase
 
     public function testPopWhenJobsAvailable()
     {
+        $this->subscription->expects($this->once())
+            ->method('acknowledge');
+
         $this->subscription->method('pull')
             ->willReturn([$this->message]);
 
@@ -132,6 +135,9 @@ class PubSubQueueTests extends TestCase
 
     public function testPopWhenNoJobAvailable()
     {
+        $this->subscription->expects($this->exactly(0))
+            ->method('acknowledge');
+
         $this->subscription->method('pull')
             ->willReturn([]);
 
@@ -187,17 +193,11 @@ class PubSubQueueTests extends TestCase
         $this->queue->acknowledge($this->message);
     }
 
-    public function testAcknowledgeAndPublish()
+    public function testRepublish()
     {
         $options = ['foo' => 'bar'];
         $delay = 60;
         $delay_timestamp = Carbon::now()->addSeconds($delay)->getTimestamp();
-
-        $this->subscription->expects($this->once())
-            ->method('acknowledge');
-
-        $this->topic->method('subscription')
-            ->willReturn($this->subscription);
 
         $this->queue->method('getTopic')
             ->willReturn($this->topic);
@@ -226,7 +226,7 @@ class PubSubQueueTests extends TestCase
                 })
             );
 
-        $this->queue->acknowledgeAndPublish($this->message, 'test', $options, $delay);
+        $this->queue->republish($this->message, 'test', $options, $delay);
     }
 
     public function testGetTopic()


### PR DESCRIPTION
## Overview

If a job is particularly long-running, waiting to acknowledge the message until after the job is finished could cause it to be added back, if the subscription has a short acknowledgement deadline.

Also, since `release` will republish the message, it's safe to acknowledge the message immediately.

## Changes

When a job is popped off the queue, the PubSub message is now immediately acknowledged. This is in contrast to the previous implementation, which waited until the job was completed to acknowledge the message.

### Back-end

- `PubSubQueue::pop` added `$this->acknowledge` so that the message is immediately acknowledged
- `PubSubQueue::acknowledgeAndPublish` was renamed `republish`, and the `acknowledge` was removed, since this was already done during `pop`.
- `PubSubJob::delete` was removed so that the parent method will be called instead, and acknowledgement won't be redone.

### Testing

Additional unit tests added to ensure that `acknowledge` is called when `pop` is called, but not if no messages are returned.

---

Please note that the build failures will be fixed by #6.