### PR TITLE
Prepares for deprecated methods being removed in Laravel 5.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,9 @@
     ],
     "require": {
         "php" : ">=7.1",
+        "ext-json": "*",
         "illuminate/queue": "5.7.* | 5.8.*",
+        "illuminate/support": "5.7.* | 5.8.*",
         "google/cloud-pubsub": "^1.1"
     },
     "require-dev": {

--- a/src/Connectors/PubSubConnector.php
+++ b/src/Connectors/PubSubConnector.php
@@ -2,6 +2,7 @@
 
 namespace Kainxspirits\PubSubQueue\Connectors;
 
+use Illuminate\Support\Str;
 use Google\Cloud\PubSub\PubSubClient;
 use Kainxspirits\PubSubQueue\PubSubQueue;
 use Illuminate\Queue\Connectors\ConnectorInterface;
@@ -58,6 +59,6 @@ class PubSubConnector implements ConnectorInterface
      */
     protected function transformConfigKeys($item, $key)
     {
-        return [camel_case($key), $item];
+        return [Str::camel($key), $item];
     }
 }


### PR DESCRIPTION
Converts deprecated helper methods to it's matching Illuminate\Support\Str equivalents as these helpers will be removed in Laravel 5.9.

Adds dependencies for illuminate/support and ext-json to composer config.