### PR TITLE
Hotfix to cast non-string values to string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor
 composer.lock
+.idea

--- a/src/PubSubQueue.php
+++ b/src/PubSubQueue.php
@@ -92,7 +92,7 @@ class PubSubQueue extends Queue implements QueueContract
         $publish = ['data' => base64_encode($payload)];
 
         if (! empty($options)) {
-            $publish['attributes'] = $options;
+            $publish['attributes'] = $this->castAttributes($options);
         }
 
         $topic->publish($publish);
@@ -210,8 +210,26 @@ class PubSubQueue extends Queue implements QueueContract
 
         return $topic->publish([
             'data' => $message->data(),
-            'attributes' => $options,
+            'attributes' => $this->castAttributes($options),
         ]);
+    }
+
+    /**
+     * Cast all attributes to 'string'
+     *
+     * this is required because google PubSub does only accept string values for attributes.
+     *
+     * @param $options
+     *
+     * @return array
+     */
+    private function castAttributes($options)
+    {
+        foreach ($options as $key => &$value) {
+            $value = (string) $value;
+        }
+
+        return $options;
     }
 
     /**

--- a/src/PubSubQueue.php
+++ b/src/PubSubQueue.php
@@ -215,7 +215,7 @@ class PubSubQueue extends Queue implements QueueContract
     }
 
     /**
-     * Cast all attributes to 'string'
+     * Cast all attributes to string.
      *
      * this is required because google PubSub does only accept string values for attributes.
      *

--- a/tests/Unit/PubSubQueueTests.php
+++ b/tests/Unit/PubSubQueueTests.php
@@ -79,7 +79,7 @@ class PubSubQueueTests extends TestCase
             ->with($this->callback(function ($publish) use ($payload) {
                 $decoded_payload = base64_decode($publish['data']);
 
-                if (!isset($publish['attributes']['numericValue']) || $publish['attributes']['numericValue'] !== (string)123456) {
+                if (! isset($publish['attributes']['numericValue']) || $publish['attributes']['numericValue'] !== (string) 123456) {
                     return false;
                 }
 


### PR DESCRIPTION
When i queue a delayed job by using ->delay() method on a job i get this message

Google/Cloud/Core/Exception/BadRequestException with message '{
  "error": {
    "code": 400,
    "message": "Invalid value at 'messages[0].attributes[0].value' (TYPE_STRING), 1559631875",
    "status": "INVALID_ARGUMENT",
    "details": [
      {
        "@type": "type.googleapis.com/google.rpc.BadRequest",
        "fieldViolations": [
          {
            "field": "messages[0].attributes[0].value",
            "description": "Invalid value at 'messages[0].attributes[0].value' (TYPE_STRING), 1559631875"
          }
        ]
      }
    ]
  }
}


This is because google pubsub only accept strings as values and not numeric values,

My PR fixes this, i also modified and added something to test this.

Hope can be merged soon, as would like to prevent another required fork.

Thanks
