### PR TITLE
Bugfix to cast available at attribute to string

### DIFF
--- a/src/PubSubQueue.php
+++ b/src/PubSubQueue.php
@@ -117,7 +117,7 @@ class PubSubQueue extends Queue implements QueueContract
         return $this->pushRaw(
             $this->createPayload($job, $this->getQueue($queue), $data),
             $queue,
-            ['available_at' => $this->availableAt($delay)]
+            ['available_at' => (string) $this->availableAt($delay)]
         );
     }
 
@@ -205,7 +205,7 @@ class PubSubQueue extends Queue implements QueueContract
         $subscription->acknowledge($message);
 
         $options = array_merge([
-            'available_at' => $this->availableAt($delay),
+            'available_at' => (string) $this->availableAt($delay),
         ], $options);
 
         return $topic->publish([

--- a/tests/Unit/PubSubQueueTests.php
+++ b/tests/Unit/PubSubQueueTests.php
@@ -107,7 +107,7 @@ class PubSubQueueTests extends TestCase
                 $this->isType('string'),
                 $this->anything(),
                 $this->callback(function ($options) use ($delay_timestamp) {
-                    if (! isset($options['available_at']) || $options['available_at'] !== $delay_timestamp) {
+                    if (! isset($options['available_at']) || $options['available_at'] !== (string) $delay_timestamp) {
                         return false;
                     }
 
@@ -229,7 +229,7 @@ class PubSubQueueTests extends TestCase
                         return false;
                     }
 
-                    if (! isset($message['attributes']['available_at']) || $message['attributes']['available_at'] !== $delay_timestamp) {
+                    if (! isset($message['attributes']['available_at']) || $message['attributes']['available_at'] !== (string) $delay_timestamp) {
                         return false;
                     }
 


### PR DESCRIPTION
As requested i left out the cast for all attributes, 
i wasn't sure if the input would be safe, therefore i added it.

If you say it's safe to only cast the available_at attribute.

This should be enough, including fixes for your unit tests.

Fixes issue #19 