### PR TITLE
Feature/configurable pull and acknowledge timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ You can check [Google Cloud PubSub client](http://googleapis.github.io/google-cl
 ],
 ```
 
+#### Additional configuration settings: 
+
+`acknowledge_deadline` The number of seconds, you want to set the acknowledge deadline to. If you run more then one worker for a configured queue. This *must* match or exceed the highest value of `--time-out` flag on all the workers for the configured queue.
+
+`pull_timeout` Because PubSub can return 0 messages, even when there messages in the queue. You can set a timeout in seconds. This keeps the driver observing the PubSub subscription for the given time. You should only need this if you run a worker with the `--exit-on-empty` flag.
 ## Testing
 
 You can run the tests with :

--- a/src/Connectors/PubSubConnector.php
+++ b/src/Connectors/PubSubConnector.php
@@ -29,7 +29,7 @@ class PubSubConnector implements ConnectorInterface
         return new PubSubQueue(
             new PubSubClient($gcp_config),
             $config['queue'] ?? $this->default_queue,
-            $config['subscriber'] ?? 'subscriber'
+            $config
         );
     }
 

--- a/src/Jobs/PubSubJob.php
+++ b/src/Jobs/PubSubJob.php
@@ -101,7 +101,7 @@ class PubSubJob extends Job implements JobContract
         $this->pubsub->acknowledgeAndPublish(
             $this->job,
             $this->queue,
-            ['attempts' => $attempts],
+            ['attempts' => (string) $attempts],
             $delay
         );
     }

--- a/src/PubSubQueue.php
+++ b/src/PubSubQueue.php
@@ -53,7 +53,7 @@ class PubSubQueue extends Queue implements QueueContract
      * @param \Google\Cloud\PubSub\PubSubClient $pubsub
      * @param string $default
      */
-    public function __construct(PubSubClient $pubsub, $default, $config)
+    public function __construct(PubSubClient $pubsub, $default, $config = [])
     {
         $this->pubsub              = $pubsub;
         $this->default             = $default;
@@ -61,7 +61,14 @@ class PubSubQueue extends Queue implements QueueContract
         $this->pullTimeout         = $config['pull_timeout'] ?? 0;
         $this->acknowledgeDeadline = $config['acknowledge_deadline'] ?? 60;
     }
-
+    
+    /**
+     * @return int
+     */
+    public function getAcknowledgeDeadline(): int
+    {
+        return $this->acknowledgeDeadline;
+    }
     /**
      * Get the size of the queue.
      * PubSubClient have no method to retrieve the size of the queue.
@@ -162,7 +169,7 @@ class PubSubQueue extends Queue implements QueueContract
             }
         } while(($this->pullTimeout-- > 0) && (count($messages) <= 0));
         if (count($messages) > 0) {
-            $subscription->modifyAckDeadline($messages[0], $this->acknowledgeDeadline);
+            $subscription->modifyAckDeadline($messages[0], $this->getAcknowledgeDeadline());
             return new PubSubJob(
                 $this->container,
                 $this,

--- a/src/PubSubQueue.php
+++ b/src/PubSubQueue.php
@@ -35,14 +35,14 @@ class PubSubQueue extends Queue implements QueueContract
 
     /**
      * Default acknowledge deadline, when popping a job from the queue.
-     * 
+     *
      * @var int
      */
     protected $acknowledgeDeadline;
 
     /**
      * The timeout to keep trying to pull from the PubSub subscription.
-     * 
+     *
      * @var int
      */
     protected $pullTimeout;
@@ -55,13 +55,13 @@ class PubSubQueue extends Queue implements QueueContract
      */
     public function __construct(PubSubClient $pubsub, $default, $config = [])
     {
-        $this->pubsub              = $pubsub;
-        $this->default             = $default;
-        $this->subscriber          = $config['subscriber'] ?? 'subscriber';
-        $this->pullTimeout         = $config['pull_timeout'] ?? 0;
+        $this->pubsub = $pubsub;
+        $this->default = $default;
+        $this->subscriber = $config['subscriber'] ?? 'subscriber';
+        $this->pullTimeout = $config['pull_timeout'] ?? 0;
         $this->acknowledgeDeadline = $config['acknowledge_deadline'] ?? 60;
     }
-    
+
     /**
      * @return int
      */
@@ -167,9 +167,10 @@ class PubSubQueue extends Queue implements QueueContract
             if ($this->pullTimeout > 0) {
                 sleep(1);
             }
-        } while(($this->pullTimeout-- > 0) && (count($messages) <= 0));
+        } while (($this->pullTimeout-- > 0) && (count($messages) <= 0));
         if (count($messages) > 0) {
             $subscription->modifyAckDeadline($messages[0], $this->getAcknowledgeDeadline());
+
             return new PubSubJob(
                 $this->container,
                 $this,

--- a/tests/Unit/Jobs/PubSubJobTests.php
+++ b/tests/Unit/Jobs/PubSubJobTests.php
@@ -87,7 +87,24 @@ class PubSubJobTests extends TestCase
     public function testReleaseAcknowledgeAndPublish()
     {
         $this->queue->expects($this->once())
-            ->method('acknowledgeAndPublish');
+            ->method('acknowledgeAndPublish')
+            ->with(
+                $this->anything(),
+                $this->anything(),
+                $this->callback(function ($options) {
+                    if (! is_array($options)) {
+                        return false;
+                    }
+
+                    foreach ($options as $key => $option) {
+                        if (! is_string($option) || ! is_string($key)) {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                })
+            );
 
         $this->job->release();
     }

--- a/tests/Unit/PubSubQueueTests.php
+++ b/tests/Unit/PubSubQueueTests.php
@@ -181,7 +181,6 @@ class PubSubQueueTests extends TestCase
 
     public function testPopWhenNoJobAvailablePullTimeout()
     {
-
         $queue = $this->getMockBuilder(PubSubQueue::class)
                       ->setConstructorArgs([$this->client, 'default', ['pull_timeout' => 1]])
                       ->setMethods(['getTopic'])
@@ -231,7 +230,6 @@ class PubSubQueueTests extends TestCase
 
     public function testPopWithoutAcknowledgeDeadline()
     {
-
         $queue = $this->getMockBuilder(PubSubQueue::class)
                       ->setConstructorArgs([$this->client, 'default'])
                       ->setMethods(['getTopic'])


### PR DESCRIPTION
After some investigation using returnImmediatly is quite risky duo to client side connection termination..

See:
https://github.com/googleapis/google-cloud-php/issues/710

I now solved it, to configure a timeout to keep pulling with returnImmediately => true for a specific period of time.

I wonder. If we should mention in the readme, that configure-ing acknowledge_deadline is required, if you run more then one worker per queue.

I also have your unmerged open branch inside, because i already merged it into my fork, as i needed it to get the attempts property to work...

I set the default acknowledge deadline to 60 seconds, as this is also the default timeout that workers have if, no flags are passed...


