### PR TITLE
Optional subscription and topic creation

### DIFF
--- a/src/Connectors/PubSubConnector.php
+++ b/src/Connectors/PubSubConnector.php
@@ -30,7 +30,8 @@ class PubSubConnector implements ConnectorInterface
             new PubSubClient($gcp_config),
             $config['queue'] ?? $this->default_queue,
             $config['subscriber'] ?? 'subscriber',
-            $config['create_topics'] ?? true
+            $config['create_topics'] ?? true,
+            $config['create_subscriptions'] ?? true
         );
     }
 

--- a/src/Connectors/PubSubConnector.php
+++ b/src/Connectors/PubSubConnector.php
@@ -29,7 +29,8 @@ class PubSubConnector implements ConnectorInterface
         return new PubSubQueue(
             new PubSubClient($gcp_config),
             $config['queue'] ?? $this->default_queue,
-            $config['subscriber'] ?? 'subscriber'
+            $config['subscriber'] ?? 'subscriber',
+            $config['create_topics'] ?? true
         );
     }
 

--- a/src/PubSubQueue.php
+++ b/src/PubSubQueue.php
@@ -34,14 +34,14 @@ class PubSubQueue extends Queue implements QueueContract
     protected $subscriber;
 
     /**
-     * Create topics automatically
+     * Create topics automatically.
      *
      * @var bool
      */
     protected $topicAutoCreation;
 
     /**
-     * Create subscriptions automatically
+     * Create subscriptions automatically.
      *
      * @var bool
      */

--- a/src/PubSubQueue.php
+++ b/src/PubSubQueue.php
@@ -41,17 +41,25 @@ class PubSubQueue extends Queue implements QueueContract
     protected $topicAutoCreation;
 
     /**
+     * Create subscriptions automatically
+     *
+     * @var bool
+     */
+    protected $subscriptionAutoCreation;
+
+    /**
      * Create a new GCP PubSub instance.
      *
      * @param \Google\Cloud\PubSub\PubSubClient $pubsub
      * @param string $default
      */
-    public function __construct(PubSubClient $pubsub, $default, $subscriber = 'subscriber', $topicAutoCreation = true)
+    public function __construct(PubSubClient $pubsub, $default, $subscriber = 'subscriber', $topicAutoCreation = true, $subscriptionAutoCreation = true)
     {
         $this->pubsub = $pubsub;
         $this->default = $default;
         $this->subscriber = $subscriber;
         $this->topicAutoCreation = $topicAutoCreation;
+        $this->subscriptionAutoCreation = $subscriptionAutoCreation;
     }
 
     /**
@@ -139,7 +147,7 @@ class PubSubQueue extends Queue implements QueueContract
     {
         $topic = $this->getTopic($this->getQueue($queue));
 
-        if (! $topic->exists()) {
+        if ($this->topicAutoCreation && ! $topic->exists()) {
             return;
         }
 
@@ -301,7 +309,8 @@ class PubSubQueue extends Queue implements QueueContract
     {
         $subscription = $topic->subscription($this->getSubscriberName());
 
-        if (! $subscription->exists()) {
+        // don't check subscription if automatic creation is not required, to avoid additional administrator operations calls
+        if ($this->subscriptionAutoCreation && ! $subscription->exists()) {
             $subscription = $topic->subscribe($this->getSubscriberName());
         }
 


### PR DESCRIPTION
In high throughput system automatic creation of topic and subscriptions cause very high usage of "Administrator operations per minute" quota which is 6000 per minute and can't be increased (Google\Cloud\Core\Exception\ServiceException: { "error": { "code": 429, "message": "Quota exceeded for quota metric 'Administrator operations' and limit 'Administrator operations per minute' ... }. It makes driver unusable. Problem could be solved by disabling automatic creation, avoiding "exists" calls and manual creation of all queues and subscriptions in GCP