### PR TITLE
Add prefixes to queue names.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ You can check [Google Cloud PubSub client](http://googleapis.github.io/google-cl
 'pubsub' => [
     'driver' => 'pubsub',
     'queue' => env('PUBSUB_QUEUE', 'default'),
+    'queue_prefix' => env('PUBSUB_QUEUE_PREFIX', ''),
     'project_id' => env('PUBSUB_PROJECT_ID', 'your-project-id'),
     'retries' => 3,
     'request_timeout' => 60,

--- a/src/Connectors/PubSubConnector.php
+++ b/src/Connectors/PubSubConnector.php
@@ -31,7 +31,8 @@ class PubSubConnector implements ConnectorInterface
             $config['queue'] ?? $this->default_queue,
             $config['subscriber'] ?? 'subscriber',
             $config['create_topics'] ?? true,
-            $config['create_subscriptions'] ?? true
+            $config['create_subscriptions'] ?? true,
+            $config['queue_prefix'] ?? ''
         );
     }
 

--- a/src/Connectors/PubSubConnector.php
+++ b/src/Connectors/PubSubConnector.php
@@ -29,7 +29,9 @@ class PubSubConnector implements ConnectorInterface
         return new PubSubQueue(
             new PubSubClient($gcp_config),
             $config['queue'] ?? $this->default_queue,
-            $config['subscriber'] ?? 'subscriber'
+            $config['subscriber'] ?? 'subscriber',
+            $config['create_topics'] ?? true,
+            $config['create_subscriptions'] ?? true
         );
     }
 

--- a/src/PubSubQueue.php
+++ b/src/PubSubQueue.php
@@ -357,11 +357,11 @@ class PubSubQueue extends Queue implements QueueContract
     {
         $queue = $queue ?: $this->default;
 
-        if (!$this->queuePrefix || Str::startsWith($queue, $this->queuePrefix)) {
+        if (! $this->queuePrefix || Str::startsWith($queue, $this->queuePrefix)) {
             return $queue;
         }
-        
-        return $this->queuePrefix . $queue;
+
+        return $this->queuePrefix.$queue;
     }
 
     /**

--- a/src/PubSubQueue.php
+++ b/src/PubSubQueue.php
@@ -48,18 +48,26 @@ class PubSubQueue extends Queue implements QueueContract
     protected $subscriptionAutoCreation;
 
     /**
+     * Prepend all queue names with this prefix.
+     *
+     * @var string
+     */
+    protected $queuePrefix = '';
+
+    /**
      * Create a new GCP PubSub instance.
      *
      * @param \Google\Cloud\PubSub\PubSubClient $pubsub
      * @param string $default
      */
-    public function __construct(PubSubClient $pubsub, $default, $subscriber = 'subscriber', $topicAutoCreation = true, $subscriptionAutoCreation = true)
+    public function __construct(PubSubClient $pubsub, $default, $subscriber = 'subscriber', $topicAutoCreation = true, $subscriptionAutoCreation = true, $queuePrefix = '')
     {
         $this->pubsub = $pubsub;
         $this->default = $default;
         $this->subscriber = $subscriber;
         $this->topicAutoCreation = $topicAutoCreation;
         $this->subscriptionAutoCreation = $subscriptionAutoCreation;
+        $this->queuePrefix = $queuePrefix;
     }
 
     /**
@@ -347,7 +355,13 @@ class PubSubQueue extends Queue implements QueueContract
      */
     public function getQueue($queue)
     {
-        return $queue ?: $this->default;
+        $queue = $queue ?: $this->default;
+
+        if (!$this->queuePrefix || Str::startsWith($queue, $this->queuePrefix)) {
+            return $queue;
+        }
+        
+        return $this->queuePrefix . $queue;
     }
 
     /**

--- a/tests/Unit/Connectors/PubSubConnectorTests.php
+++ b/tests/Unit/Connectors/PubSubConnectorTests.php
@@ -27,6 +27,24 @@ class PubSubConnectorTests extends TestCase
         $this->assertEquals($queue->getSubscriberName(), 'test-subscriber');
     }
 
+    public function testQueuePrefixAdded()
+    {
+        $connector = new PubSubConnector();
+        $config = $this->createFakeConfig() + ['queue_prefix' => 'prefix-'];
+        $queue = $connector->connect($config);
+
+        $this->assertEquals('prefix-my-queue', $queue->getQueue('my-queue'));
+    }
+
+    public function testNotQueuePrefixAddedMultipleTimes()
+    {
+        $connector = new PubSubConnector();
+        $config = $this->createFakeConfig() + ['queue_prefix' => 'prefix-'];
+        $queue = $connector->connect($config);
+
+        $this->assertEquals('prefix-default', $queue->getQueue($queue->getQueue('default')));
+    }
+
     private function createFakeConfig()
     {
         return [


### PR DESCRIPTION
At the moment, queue names have no prefixes defined.

This makes it cumbersome to run multiple client projects within a single Google Cloud project that all use Pub/Sub. If all the client projects have a queue of `default`, then you need to remember to manually add a prefix to all instances where you push onto a specific queue (for example: `Illuminate\Support\Facades\Queue::pushOn('client1-default', function() { });`).

This PR adds an additional config key of `queue_prefix`, which ensures that all queue names will be prefixed with the given value. This means that client projects can push a job onto the `default` queue without worrying about clashing queue names.

So, as an example, `Illuminate\Support\Facades\Queue::pushOn('default', function() { });` for client 1 will push to the `client1-default` queue, and `Illuminate\Support\Facades\Queue::pushOn('default', function() { });` will push to the `client2-default` queue transparently.