### PR TITLE
Allow consuming multiple subs

### DIFF
--- a/src/Commands/PubSubConsume.php
+++ b/src/Commands/PubSubConsume.php
@@ -26,10 +26,7 @@ class PubSubConsume extends Command
     {
         $this->setSubscriptionToConsume($this->getSubscriptionName());
 
-        Artisan::call('queue:work', [
-            'connection' => 'pubsub',
-            '--sleep' => $this->getSleepOption()
-        ]);
+        Artisan::call('queue:work', ['connection' => 'pubsub', '--sleep' => $this->getSleepOption()]);
     }
 
     /**

--- a/src/Commands/PubSubConsume.php
+++ b/src/Commands/PubSubConsume.php
@@ -26,7 +26,10 @@ class PubSubConsume extends Command
     {
         $this->setSubscriptionToConsume($this->getSubscriptionName());
 
-        Artisan::call('queue:work', ['connection' => 'pubsub', '--sleep' => $this->getSleepOption()]);
+        Artisan::call('queue:work',
+            ['connection' => 'pubsub', '--sleep' => $this->getSleepOption()],
+            $this->output
+        );
     }
 
     /**

--- a/src/Commands/PubSubConsume.php
+++ b/src/Commands/PubSubConsume.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Kainxspirits\PubSubQueue\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Artisan;
+
+class PubSubConsume extends Command
+{
+    /**
+     * @var string
+     */
+    protected $signature = 'pubsub:consume
+                            {sub-name : The name of the sub to consume}
+                            {--sleep=3 : Number of seconds to sleep when no job is available}';
+
+    /**
+     * @var string
+     */
+    protected $description = 'Start processing messages on the specified subscription';
+
+    /**
+     * @return void
+     */
+    public function handle(): void
+    {
+        $this->setSubscriptionToConsume($this->getSubscriptionName());
+
+        Artisan::call('queue:work', [
+            'connection' => 'pubsub',
+            '--sleep' => $this->getSleepOption()
+        ]);
+    }
+
+    /**
+     * @param string $subscriptionName
+     *
+     * @return void
+     */
+    private function setSubscriptionToConsume(string $subscriptionName): void
+    {
+        config(['queue.connections.pubsub.subscriber' => $subscriptionName]);
+    }
+
+    /**
+     * @return string
+     */
+    private function getSubscriptionName(): string
+    {
+        return $this->argument('sub-name');
+    }
+
+    /**
+     * @return string
+     */
+    private function getSleepOption(): string
+    {
+        return $this->option('sleep');
+    }
+}

--- a/src/PubSubQueueServiceProvider.php
+++ b/src/PubSubQueueServiceProvider.php
@@ -39,4 +39,3 @@ class PubSubQueueServiceProvider extends ServiceProvider
         }
     }
 }
-

--- a/src/PubSubQueueServiceProvider.php
+++ b/src/PubSubQueueServiceProvider.php
@@ -3,19 +3,40 @@
 namespace Kainxspirits\PubSubQueue;
 
 use Illuminate\Support\ServiceProvider;
+use Kainxspirits\PubSubQueue\Commands\PubSubConsume;
 use Kainxspirits\PubSubQueue\Connectors\PubSubConnector;
 
 class PubSubQueueServiceProvider extends ServiceProvider
 {
     /**
-     * Bootstrap any application services.
-     *
      * @return void
      */
-    public function boot()
+    public function boot(): void
     {
-        $this->app['queue']->addConnector('pubsub', function () {
+        $this->registerPubSubCommands();
+        $this->addPubSubConnector();
+    }
+
+    /**
+     * @return void
+     */
+    private function addPubSubConnector(): void
+    {
+        $this->app['queue']->addConnector('pubsub', static function () {
             return new PubSubConnector;
         });
     }
+
+    /**
+     * @return void
+     */
+    private function registerPubSubCommands(): void
+    {
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                PubSubConsume::class,
+            ]);
+        }
+    }
 }
+


### PR DESCRIPTION
MVP Solution 🤖 ❗
 
Simple wrapper command will allow consuming multiple subs. Currently, the package can only consume one sub via `queue:work` command  (--queue does not change sub), because it's a static variable defined in config. 😞

Ideally, consuming and publishing should be decoupled and customizable, but we have what we have 😄  🚀  Agile and MVP FTW 📈 

