### PR TITLE
Add support for Laravel 9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,38 @@
+name: Build
+
+on:
+  push:
+    paths-ignore: ['*.md']
+  pull_request:
+    branches: [master]
+    paths-ignore: ['*.md']
+
+jobs:
+  test:
+    name: Test (PHP ${{ matrix.php }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php: [7.4, 8.0, 8.1]
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: json
+      - name: Cache composer dependencies
+        uses: actions/cache@v2
+        env:
+          cache-name: laravel-pubsub-queue
+        with:
+          path: ~/.composer
+          key: php-${{ matrix.php }}-build-${{ env.cache-name }}-${{ hashFiles('**/composer.json') }}
+          restore-keys: |
+            php-${{ matrix.php }}-build-${{ env.cache-name }}-
+            php-${{ matrix.php }}-build-
+            php-${{ matrix.php }}-
+      - name: Install composer dependencies
+        run: composer install --prefer-dist
+      - name: Run the test suite
+        run: phpdbg -qrr -dmemory_limit=-1 vendor/bin/phpunit --coverage-text

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
     "require": {
         "php" : ">=7.2",
         "ext-json": "*",
-        "illuminate/queue": "5.7.* | 5.8.* | ^6.0 | ^7.0 | ^8.0",
-        "illuminate/support": "5.7.* | 5.8.* | ^6.0 | ^7.0 | ^8.0",
+        "illuminate/queue": "5.7.* | 5.8.* | ^6.0 | ^7.0 | ^8.0 | ^9.0",
+        "illuminate/support": "5.7.* | 5.8.* | ^6.0 | ^7.0 | ^8.0 | ^9.0",
         "google/cloud-pubsub": "^1.1",
         "ramsey/uuid": "^2.0|^3.0|^4.0"
     },

--- a/src/Jobs/PubSubJob.php
+++ b/src/Jobs/PubSubJob.php
@@ -27,11 +27,11 @@ class PubSubJob extends Job implements JobContract
     /**
      * Create a new job instance.
      *
-     * @param \Illuminate\Container\Container $container
-     * @param \Kainxspirits\PubSubQueue\PubSubQueue $sqs
-     * @param \Google\Cloud\PubSub\Message $job
-     * @param string       $connectionName
-     * @param string       $queue
+     * @param  \Illuminate\Container\Container  $container
+     * @param  \Kainxspirits\PubSubQueue\PubSubQueue  $sqs
+     * @param  \Google\Cloud\PubSub\Message  $job
+     * @param  string  $connectionName
+     * @param  string  $queue
      */
     public function __construct(Container $container, PubSubQueue $pubsub, Message $job, $connectionName, $queue)
     {
@@ -77,7 +77,7 @@ class PubSubJob extends Job implements JobContract
     /**
      * Release the job back into the queue.
      *
-     * @param  int   $delay
+     * @param  int  $delay
      * @return void
      */
     public function release($delay = 0)

--- a/src/Jobs/PubSubJob.php
+++ b/src/Jobs/PubSubJob.php
@@ -20,7 +20,7 @@ class PubSubJob extends Job implements JobContract
     /**
      * The job instance.
      *
-     * @var array
+     * @var Message
      */
     protected $job;
 

--- a/tests/Unit/PubSubQueueTests.php
+++ b/tests/Unit/PubSubQueueTests.php
@@ -202,6 +202,9 @@ class PubSubQueueTests extends TestCase
         $this->queue->method('getTopic')
             ->willReturn($this->topic);
 
+        $this->message->method('data')
+            ->willReturn(base64_encode(json_encode(['foo' => 'bar'])));
+
         $this->queue->setContainer($this->createMock(Container::class));
 
         $this->assertTrue($this->queue->pop('test') instanceof PubSubJob);

--- a/tests/Unit/PubSubQueueTests.php
+++ b/tests/Unit/PubSubQueueTests.php
@@ -142,7 +142,7 @@ class PubSubQueueTests extends TestCase
                 'foo' => 'bar',
             ],
             1 => 'wrong key',
-            'object' => new \StdClass,
+            'object' => new \stdClass,
         ];
 
         $queue->pushRaw($payload, '', $options);
@@ -383,7 +383,7 @@ class PubSubQueueTests extends TestCase
                 'foo' => 'bar',
             ],
             1 => 'wrong key',
-            'object' => new \StdClass,
+            'object' => new \stdClass,
         ];
 
         $this->queue->republish($this->message, 'test', $options, $delay);


### PR DESCRIPTION
* Support Laravel 9
* Fixes incorrect class propery type
* Fixes test warning message in PHP 8.1
* Initialize github action config with several php version matrixs