### PR TITLE
Horizon-support

### DIFF
--- a/src/PubSubQueue.php
+++ b/src/PubSubQueue.php
@@ -71,6 +71,19 @@ class PubSubQueue extends Queue implements QueueContract
     }
 
     /**
+     * Get the number of queue jobs that are ready to process.
+     * Used by Laravel Horizon to auto scale workers.
+     *
+     * @param $queue
+     * @return bool
+     * @see \Laravel\Horizon\RedisQueue::readyNow()
+     */
+    public function readyNow($queue = null): bool
+    {
+        return $this->size($queue) >= 0;
+    }
+
+    /**
      * Get the size of the queue.
      * PubSubClient have no method to retrieve the size of the queue.
      * To be updated if the API allow to get that data.

--- a/src/PubSubQueue.php
+++ b/src/PubSubQueue.php
@@ -57,7 +57,7 @@ class PubSubQueue extends Queue implements QueueContract
     /**
      * Create a new GCP PubSub instance.
      *
-     * @param  \Google\Cloud\PubSub\PubSubClient $pubsub
+     * @param  \Google\Cloud\PubSub\PubSubClient  $pubsub
      * @param  string $default
      */
     public function __construct(PubSubClient $pubsub, $default, $subscriber = 'subscriber', $topicAutoCreation = true, $subscriptionAutoCreation = true, $queuePrefix = '')
@@ -73,7 +73,7 @@ class PubSubQueue extends Queue implements QueueContract
     /**
      * Get the number of queue jobs that are ready to process.
      * Used by Laravel Horizon to auto scale workers.
-     * 
+     *
      * @see \Laravel\Horizon\RedisQueue::readyNow()
      *
      * @param  string|null  $queue
@@ -115,7 +115,7 @@ class PubSubQueue extends Queue implements QueueContract
      *
      * @param  string  $payload
      * @param  string  $queue
-     * @param  array   $options
+     * @param  array  $options
      * @return array
      */
     public function pushRaw($payload, $queue = null, array $options = [])
@@ -198,8 +198,8 @@ class PubSubQueue extends Queue implements QueueContract
     /**
      * Push an array of jobs onto the queue.
      *
-     * @param  array   $jobs
-     * @param  mixed   $data
+     * @param  array  $jobs
+     * @param  mixed  $data
      * @param  string  $queue
      * @return mixed
      */
@@ -222,8 +222,8 @@ class PubSubQueue extends Queue implements QueueContract
     /**
      * Acknowledge a message.
      *
-     * @param  \Google\Cloud\PubSub\Message $message
-     * @param  string $queue
+     * @param  \Google\Cloud\PubSub\Message  $message
+     * @param  string  $queue
      */
     public function acknowledge(Message $message, $queue = null)
     {
@@ -271,9 +271,10 @@ class PubSubQueue extends Queue implements QueueContract
      * Check if the attributes array only contains key-values
      * pairs made of strings.
      *
-     * @param  array $attributes
-     * @throws \UnexpectedValueException
+     * @param  array  $attributes
      * @return array
+     *
+     * @throws \UnexpectedValueException
      */
     private function validateMessageAttributes($attributes): array
     {
@@ -295,8 +296,8 @@ class PubSubQueue extends Queue implements QueueContract
     /**
      * Get the current topic.
      *
-     * @param  string $queue
-     * @param  string $create
+     * @param  string  $queue
+     * @param  string  $create
      * @return \Google\Cloud\PubSub\Topic
      */
     public function getTopic($queue, $create = false)

--- a/src/PubSubQueue.php
+++ b/src/PubSubQueue.php
@@ -58,7 +58,7 @@ class PubSubQueue extends Queue implements QueueContract
      * Create a new GCP PubSub instance.
      *
      * @param  \Google\Cloud\PubSub\PubSubClient  $pubsub
-     * @param  string $default
+     * @param  string  $default
      */
     public function __construct(PubSubClient $pubsub, $default, $subscriber = 'subscriber', $topicAutoCreation = true, $subscriptionAutoCreation = true, $queuePrefix = '')
     {
@@ -101,7 +101,7 @@ class PubSubQueue extends Queue implements QueueContract
      * Push a new job onto the queue.
      *
      * @param  string|object  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @param  string  $queue
      * @return mixed
      */
@@ -142,7 +142,7 @@ class PubSubQueue extends Queue implements QueueContract
      *
      * @param  \DateTimeInterface|\DateInterval|int  $delay
      * @param  string|object  $job
-     * @param  mixed   $data
+     * @param  mixed  $data
      * @param  string  $queue
      * @return mixed
      */
@@ -234,8 +234,8 @@ class PubSubQueue extends Queue implements QueueContract
     /**
      * Republish a message onto the queue.
      *
-     * @param  \Google\Cloud\PubSub\Message $message
-     * @param  string $queue
+     * @param  \Google\Cloud\PubSub\Message  $message
+     * @param  string  $queue
      * @return mixed
      */
     public function republish(Message $message, $queue = null, $options = [], $delay = 0)

--- a/src/PubSubQueue.php
+++ b/src/PubSubQueue.php
@@ -57,8 +57,8 @@ class PubSubQueue extends Queue implements QueueContract
     /**
      * Create a new GCP PubSub instance.
      *
-     * @param \Google\Cloud\PubSub\PubSubClient $pubsub
-     * @param string $default
+     * @param  \Google\Cloud\PubSub\PubSubClient $pubsub
+     * @param  string $default
      */
     public function __construct(PubSubClient $pubsub, $default, $subscriber = 'subscriber', $topicAutoCreation = true, $subscriptionAutoCreation = true, $queuePrefix = '')
     {
@@ -73,10 +73,10 @@ class PubSubQueue extends Queue implements QueueContract
     /**
      * Get the number of queue jobs that are ready to process.
      * Used by Laravel Horizon to auto scale workers.
+     * 
      * @see \Laravel\Horizon\RedisQueue::readyNow()
      *
      * @param  string|null  $queue
-     * 
      * @return int
      */
     public function readyNow($queue = null)
@@ -90,7 +90,6 @@ class PubSubQueue extends Queue implements QueueContract
      * To be updated if the API allow to get that data.
      *
      * @param  string  $queue
-     *
      * @return int
      */
     public function size($queue = null)
@@ -104,7 +103,6 @@ class PubSubQueue extends Queue implements QueueContract
      * @param  string|object  $job
      * @param  mixed   $data
      * @param  string  $queue
-     *
      * @return mixed
      */
     public function push($job, $data = '', $queue = null)
@@ -118,7 +116,6 @@ class PubSubQueue extends Queue implements QueueContract
      * @param  string  $payload
      * @param  string  $queue
      * @param  array   $options
-     *
      * @return array
      */
     public function pushRaw($payload, $queue = null, array $options = [])
@@ -147,7 +144,6 @@ class PubSubQueue extends Queue implements QueueContract
      * @param  string|object  $job
      * @param  mixed   $data
      * @param  string  $queue
-     *
      * @return mixed
      */
     public function later($delay, $job, $data = '', $queue = null)
@@ -205,7 +201,6 @@ class PubSubQueue extends Queue implements QueueContract
      * @param  array   $jobs
      * @param  mixed   $data
      * @param  string  $queue
-     *
      * @return mixed
      */
     public function bulk($jobs, $data = '', $queue = null)
@@ -241,7 +236,6 @@ class PubSubQueue extends Queue implements QueueContract
      *
      * @param  \Google\Cloud\PubSub\Message $message
      * @param  string $queue
-     *
      * @return mixed
      */
     public function republish(Message $message, $queue = null, $options = [], $delay = 0)
@@ -278,7 +272,6 @@ class PubSubQueue extends Queue implements QueueContract
      * pairs made of strings.
      *
      * @param  array $attributes
-     *
      * @throws \UnexpectedValueException
      * @return array
      */
@@ -304,7 +297,6 @@ class PubSubQueue extends Queue implements QueueContract
      *
      * @param  string $queue
      * @param  string $create
-     *
      * @return \Google\Cloud\PubSub\Topic
      */
     public function getTopic($queue, $create = false)
@@ -324,7 +316,6 @@ class PubSubQueue extends Queue implements QueueContract
      * Create a new subscription to a topic.
      *
      * @param  \Google\Cloud\PubSub\Topic  $topic
-     *
      * @return \Google\Cloud\PubSub\Subscription
      */
     public function subscribeToTopic(Topic $topic)
@@ -343,7 +334,6 @@ class PubSubQueue extends Queue implements QueueContract
      * Get subscriber name.
      *
      * @param  \Google\Cloud\PubSub\Topic  $topic
-     *
      * @return string
      */
     public function getSubscriberName()

--- a/src/PubSubQueue.php
+++ b/src/PubSubQueue.php
@@ -73,14 +73,15 @@ class PubSubQueue extends Queue implements QueueContract
     /**
      * Get the number of queue jobs that are ready to process.
      * Used by Laravel Horizon to auto scale workers.
-     *
-     * @param $queue
-     * @return bool
      * @see \Laravel\Horizon\RedisQueue::readyNow()
+     *
+     * @param  string|null  $queue
+     * 
+     * @return int
      */
-    public function readyNow($queue = null): bool
+    public function readyNow($queue = null)
     {
-        return $this->size($queue) >= 0;
+        return $this->size($queue);
     }
 
     /**


### PR DESCRIPTION
Laravel Horizon needs a `readyNow()` function for it's auto scaling/master process to function correctly.

Just like in the original [`RedisQueue`](https://github.com/laravel/horizon/blob/master/src/RedisQueue.php#L23), this function returns the queue size. This means that the autoscaler nevers increases the amount of workers (queue size of hardcoded 0 thanks to GCP API limitations), but Horizon works as intended further on. Without this function, it won't start the worker processes. Scaling for now is done through hardcoded config variables if needed, but it will work correctly if and when Google allows for the size call to happen.