### PR TITLE
remove base64_encode/decode of the payload.

### DIFF
--- a/src/Jobs/PubSubJob.php
+++ b/src/Jobs/PubSubJob.php
@@ -68,7 +68,7 @@ class PubSubJob extends Job implements JobContract
      */
     public function getRawBody()
     {
-        return base64_decode($this->job->data());
+        return $this->job->data();
     }
 
     /**

--- a/src/PubSubQueue.php
+++ b/src/PubSubQueue.php
@@ -116,7 +116,7 @@ class PubSubQueue extends Queue implements QueueContract
 
         $this->subscribeToTopic($topic);
 
-        $publish = ['data' => base64_encode($payload)];
+        $publish = ['data' => $payload];
 
         if (! empty($options)) {
             $publish['attributes'] = $this->validateMessageAttributes($options);
@@ -204,7 +204,7 @@ class PubSubQueue extends Queue implements QueueContract
 
         foreach ((array) $jobs as $job) {
             $payload = $this->createPayload($job, $this->getQueue($queue), $data);
-            $payloads[] = ['data' => base64_encode($payload)] + (isset($job->orderingKey) ? ['orderingKey' => $job->orderingKey] : []);
+            $payloads[] = ['data' => $payload] + (isset($job->orderingKey) ? ['orderingKey' => $job->orderingKey] : []);
         }
 
         $topic = $this->getTopic($this->getQueue($queue), $this->topicAutoCreation);

--- a/tests/Unit/Jobs/PubSubJobTests.php
+++ b/tests/Unit/Jobs/PubSubJobTests.php
@@ -57,7 +57,7 @@ final class PubSubJobTests extends TestCase
     {
         $this->messageId = '1234';
         $this->messageData = json_encode(['id' => $this->messageId, 'foo' => 'bar']);
-        $this->messageEncodedData = base64_encode($this->messageData);
+        $this->messageEncodedData = $this->messageData;
 
         $this->container = $this->createMock(Container::class);
         $this->queue = $this->createMock(PubSubQueue::class);

--- a/tests/Unit/PubSubQueueTests.php
+++ b/tests/Unit/PubSubQueueTests.php
@@ -101,7 +101,7 @@ final class PubSubQueueTests extends TestCase
         $this->topic->method('publish')
             ->willReturn($this->expectedResult)
             ->with($this->callback(function ($publish) use ($payload) {
-                $decoded_payload = base64_decode($publish['data']);
+                $decoded_payload = $publish['data'];
 
                 return $decoded_payload === $payload;
             }));
@@ -203,7 +203,7 @@ final class PubSubQueueTests extends TestCase
             ->willReturn($this->topic);
 
         $this->message->method('data')
-            ->willReturn(base64_encode(json_encode(['foo' => 'bar'])));
+            ->willReturn(json_encode(['foo' => 'bar']));
 
         $this->queue->setContainer($this->createMock(Container::class));
 
@@ -275,7 +275,7 @@ final class PubSubQueueTests extends TestCase
             ->method('publishBatch')
             ->willReturn($this->expectedResult)
             ->with($this->callback(function ($payloads) use ($jobs, $data) {
-                $decoded_payload = json_decode(base64_decode($payloads[0]['data']), true);
+                $decoded_payload = json_decode($payloads[0]['data'], true);
 
                 return $decoded_payload['job'] === $jobs[0] && $decoded_payload['data'] === $data;
             }));


### PR DESCRIPTION
Google lib, which is used underneath is already properly encoding/decoding the payload. There is no need to do it twice. 
Here is some screenshots with the proofs :) 
Feel free to dive into the google pub/sub lib and check it on your own :)

![Screenshot 2024-03-26 at 15 40 07](https://github.com/kainxspirits/laravel-pubsub-queue/assets/30176019/8062584c-1e25-4fe2-9987-917f42d0787f)


As it is the non-compatible change, i suggest bumping up major version during releasing