### PR TITLE
Fix push() to working afterCommit()

### DIFF
--- a/src/PubSubQueue.php
+++ b/src/PubSubQueue.php
@@ -99,7 +99,15 @@ class PubSubQueue extends Queue implements QueueContract
             $options['orderingKey'] = $job->orderingKey;
         }
 
-        return $this->pushRaw($this->createPayload($job, $this->getQueue($queue), $data), $queue, $options);
+        return $this->enqueueUsing(
+            $job,
+            $this->createPayload($job, $this->getQueue($queue), $data),
+            $queue,
+            null,
+            function ($payload, $queue) use ($options) {
+                return $this->pushRaw($payload, $queue, $options);
+            }
+        );
     }
 
     /**

--- a/tests/Unit/PubSubQueueTests.php
+++ b/tests/Unit/PubSubQueueTests.php
@@ -76,6 +76,8 @@ final class PubSubQueueTests extends TestCase
         $job = 'test';
         $data = ['foo' => 'bar'];
 
+        $this->queue->setContainer(Container::getInstance());
+
         $this->queue->expects($this->once())
             ->method('pushRaw')
             ->willReturn($this->expectedResult)


### PR DESCRIPTION
fix to [afterCommit()](https://laravel.com/docs/11.x/queues#specifying-commit-dispatch-behavior-inline) is working.

e.g.
- [DatabaseQueue](https://github.com/laravel/framework/blob/11.x/src/Illuminate/Queue/DatabaseQueue.php#L92)
- [RedisQueue](https://github.com/laravel/framework/blob/11.x/src/Illuminate/Queue/RedisQueue.php#L144)
